### PR TITLE
Add ExpectPlatform.Transformed

### DIFF
--- a/src/main/java/me/shedaniel/architectury/annotations/ExpectPlatform.java
+++ b/src/main/java/me/shedaniel/architectury/annotations/ExpectPlatform.java
@@ -27,4 +27,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.METHOD)
 public @interface ExpectPlatform {
+    /**
+     * Marker annotation, implemented automatically on transformed {@code ExpectPlatform} methods.
+     */
+    @Retention(RetentionPolicy.CLASS)
+    @Target(ElementType.METHOD)
+    @interface Transformed {
+    }
 }


### PR DESCRIPTION
**Injectables** / [Transformer](https://github.com/architectury/architectury-transformer/pull/1) / [IDEA](https://github.com/architectury/architectury-idea-plugin/pull/1)

Adds the `@ExpectPlatform.Transformed` marker annotation for marking platform-transformed `@ExpectPlatform` methods. Used in the IDEA plugin to exclude platform-transformed "common" methods from gutter icon navigation.